### PR TITLE
Address enum types by failing on CREATE TYPE

### DIFF
--- a/pg2mysql.pl
+++ b/pg2mysql.pl
@@ -97,7 +97,7 @@ sub handle_line {
     # Explicitly die when we encounter lines we can't handle
     if ( $strict ) {
 	if ( $line =~ /CREATE TYPE / ) {
-	    die "CREATE TYPE statemets not supported";
+	    die "CREATE TYPE statements not supported";
 	}
     }
     

--- a/pg2mysql.pl
+++ b/pg2mysql.pl
@@ -42,9 +42,11 @@ use Getopt::Long;
 
 my @skip_tables;
 my $insert_ignore;
+my $strict;
 GetOptions (
     "skip=s" => \@skip_tables,
     "insert_ignore" => \$insert_ignore,
+    "strict" => \$strict
     );
 
 $| = 1;
@@ -93,8 +95,10 @@ sub handle_line {
     my $nextline = shift;
 
     # Explicitly die when we encounter lines we can't handle
-    if ( $line =~ /CREATE TYPE / ) {
-	die "CREATE TYPE statemets not supported";
+    if ( $strict ) {
+	if ( $line =~ /CREATE TYPE / ) {
+	    die "CREATE TYPE statemets not supported";
+	}
     }
     
     # Explicitly skipped statments need to be defined first.

--- a/pg2mysql.pl
+++ b/pg2mysql.pl
@@ -92,6 +92,11 @@ sub handle_line {
     my $line = shift || "";
     my $nextline = shift;
 
+    # Explicitly die when we encounter lines we can't handle
+    if ( $line =~ /CREATE TYPE / ) {
+	die "CREATE TYPE statemets not supported";
+    }
+    
     # Explicitly skipped statments need to be defined first.
     if ( $in_begin_end || $line =~ m/^\s*begin\s*$/i) {
         ($line, $in_begin_end, $skip) = handle_begin_end($line);

--- a/test/unsupported-types.bats
+++ b/test/unsupported-types.bats
@@ -149,6 +149,6 @@ ALTER TABLE ONLY public.enum_type
 --
 PGDUMP
     [ $status -ne 0 ]
-    [[ "$output" =~ "CREATE TYPE statemets not supported" ]] || false
+    [[ "$output" =~ "CREATE TYPE statements not supported" ]] || false
     
 }

--- a/test/unsupported-types.bats
+++ b/test/unsupported-types.bats
@@ -81,7 +81,7 @@ PGDUMP
 }
 
 @test "enum types" {
-    run pg2mysql.pl <<PGDUMP
+    run pg2mysql.pl --strict <<PGDUMP
 --
 -- PostgreSQL database dump
 --

--- a/test/unsupported-types.bats
+++ b/test/unsupported-types.bats
@@ -80,3 +80,75 @@ PGDUMP
      [[ "$output" =~ "08:00:2b:01:02:03" ]] || false
 }
 
+@test "enum types" {
+    run pg2mysql.pl <<PGDUMP
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 14.1
+-- Dumped by pg_dump version 14.1
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: mood; Type: TYPE; Schema: public; Owner: timsehn
+--
+
+CREATE TYPE public.mood AS ENUM (
+    'sad',
+    'ok',
+    'happy'
+);
+
+
+ALTER TYPE public.mood OWNER TO timsehn;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+
+--
+-- Name: enum_type; Type: TABLE; Schema: public; Owner: timsehn
+--
+
+CREATE TABLE public.enum_type (
+    pk integer NOT NULL,
+    c1 public.mood
+);
+
+
+ALTER TABLE public.enum_type OWNER TO timsehn;
+
+--
+-- Data for Name: enum_type; Type: TABLE DATA; Schema: public; Owner: timsehn
+--
+
+
+
+--
+-- Name: enum_type enum_type_pkey; Type: CONSTRAINT; Schema: public; Owner: timsehn
+--
+
+ALTER TABLE ONLY public.enum_type
+    ADD CONSTRAINT enum_type_pkey PRIMARY KEY (pk);
+
+
+--
+-- PostgreSQL database dump complete
+--
+PGDUMP
+    [ $status -ne 0 ]
+    [[ "$output" =~ "CREATE TYPE statemets not supported" ]] || false
+    
+}


### PR DESCRIPTION
Add error when a CREATE TYPE statement appears in the pg dump. This addresses enum types. Eventually, we would want to store the enum types in a variable and do a replace in the actual create table.