### PR TITLE
Support COPY statements & several features / fixes

### DIFF
--- a/pg2mysql.pl
+++ b/pg2mysql.pl
@@ -127,6 +127,13 @@ sub handle_line {
 
 sub handle_create {
     my $line = shift;
+    # special column names that can be replaced by a MySQL keyword
+    my @special = ('serial', 'uuid', 'text', 'character');
+
+    # temp rename special columns
+    foreach my $col ( @special ) {
+        $line =~ s/^\s{4}$col/    $col\_/g;
+    }
 
     if ( $line =~ m/^\s*CREATE TABLE (\S+)/ ) {
         # pgdump doesn't include "create database" statements for any
@@ -218,6 +225,11 @@ sub handle_create {
     $line =~ s/ \S*\.citext/ text/;
 
     my $field_def = ( $line !~ m/^CREATE/ && $line !~ m/^\s*CONSTRAINT/ && $line !~ m/\s*PRIMARY KEY/ && $line !~ m/^\s*\);/ );
+
+    # revert rename special columns
+    foreach my $col ( @special ) {
+        $line =~ s/^\s{4}$col\_/    $col/g;
+    }
 
     # backtick quote any field name as necessary
     # TODO: backtick field names in constraints as well

--- a/pg2mysql.pl
+++ b/pg2mysql.pl
@@ -215,6 +215,7 @@ sub handle_create {
     $line =~ s/ inet/ varchar\(32\)/;
     $line =~ s/ macaddr/ varchar\(32\)/;
     $line =~ s/ money/ varchar\(32\)/;
+    $line =~ s/ interval/ varchar\(64\)/;
 
     $line =~ s/ longtext DEFAULT [^,]*( NOT NULL)?/ longtext $1/; # text types can't have defaults in mysql
     $line =~ s/ DEFAULT .*\(\)//; # strip function defaults

--- a/pg2mysql.pl
+++ b/pg2mysql.pl
@@ -137,7 +137,7 @@ sub handle_create {
 
     # temp rename special columns
     foreach my $col ( @special ) {
-        $line =~ s/^\s{4}$col/    $col\_/g;
+        $line =~ s/^\s*$col/    tmp\_$col/g;
     }
 
     if ( $line =~ m/^\s*CREATE TABLE (\S+)/ ) {
@@ -239,7 +239,7 @@ sub handle_create {
 
     # revert rename special columns
     foreach my $col ( @special ) {
-        $line =~ s/^\s{4}$col\_/    $col/g;
+        $line =~ s/^\s*tmp\_$col/    $col/g;
     }
 
     # backtick quote any field name as necessary

--- a/pg2mysql.pl
+++ b/pg2mysql.pl
@@ -119,6 +119,9 @@ sub handle_line {
         return;
     }
 
+    # Very special case: key is a reserved word in MySQL, rename all
+    $line =~ s/`key`/`index`/g;
+
     print "$line\n" unless $skip;
 }
 

--- a/pg2mysql.pl
+++ b/pg2mysql.pl
@@ -174,7 +174,7 @@ sub handle_create {
     $line =~ s/ int_unsigned/ integer UNSIGNED/;
     $line =~ s/ smallint_unsigned/ smallint UNSIGNED/;
     $line =~ s/ bigint_unsigned/ bigint UNSIGNED/;
-    $line =~ s/ serial / integer auto_increment /;
+    $line =~ s/ serial/ integer auto_increment/;
     $line =~ s/ uuid/ varchar(36)/;
     $line =~ s/ bytea/ BLOB/;
     $line =~ s/ boolean/ bool/;


### PR DESCRIPTION
Hello, I stumbled upon this project while trying to convert my dump. Sadly, it was using COPY statements so I implemented a simple way to parse it.

Few improvements for MySQL import, for example the key column cannot be used (reserved) so I force renamed it. Same for special column instructions (serial as in #50, which fixes this issue)
Also added interval support by converting it to varchar (Postgres allows times, date & times, negative time, etc that cannot be implemented in MySQL this way)

I "linted" the file by replacing tabs into spaces & removed trailing spaces as well.

I hope it will be useful to anyone, and I decided to create only 1 PR, if you want me to split, I can :)